### PR TITLE
Re-use the TLSConfig from devices runner for the http runner

### DIFF
--- a/server/dev/server.go
+++ b/server/dev/server.go
@@ -96,7 +96,7 @@ func main() {
 		})
 	})
 	handler := api.PanicTo500Handler(mux, logger)
-	go server.HTTPServeRunner(nil, handler, &cfg.HTTPServeParsedConfig, nil)()
+	go server.HTTPServeRunner(nil, handler, &cfg.HTTPServeParsedConfig, cfg.DevicesParsedConfig.TLSServerConfig())()
 	// listen for device connections
 	resource := &listener.NopSessionResourceManager{}
 	server.DevicesRunner(lst, func(conn net.Conn) error {


### PR DESCRIPTION
This should now re-use the same config as is used for the devices runner so both ports should run over https now.