### PR TITLE
Initial conversion to Go modules

### DIFF
--- a/bus/accounts/accounts.go
+++ b/bus/accounts/accounts.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"sync"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	"launchpad.net/go-xdg"
 
 	"github.com/ubports/ubuntu-push/bus"

--- a/bus/accounts/accounts.go
+++ b/bus/accounts/accounts.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 
 	"launchpad.net/go-dbus/v1"
-	"launchpad.net/go-xdg/v0"
+	"launchpad.net/go-xdg"
 
 	"github.com/ubports/ubuntu-push/bus"
 	"github.com/ubports/ubuntu-push/logger"

--- a/bus/accounts/accounts_test.go
+++ b/bus/accounts/accounts_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"testing"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	testibus "github.com/ubports/ubuntu-push/bus/testing"

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -20,7 +20,7 @@ package bus
 // Here we define the Bus itself
 
 import (
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	"github.com/ubports/ubuntu-push/logger"
 )
 

--- a/bus/bus_test.go
+++ b/bus/bus_test.go
@@ -18,7 +18,7 @@ package bus
 
 import (
 	"fmt"
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 	helpers "github.com/ubports/ubuntu-push/testing"
 	"testing"

--- a/bus/connectivity/connectivity_test.go
+++ b/bus/connectivity/connectivity_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	"github.com/ubports/ubuntu-push/bus"

--- a/bus/emblemcounter/emblemcounter.go
+++ b/bus/emblemcounter/emblemcounter.go
@@ -19,7 +19,7 @@
 package emblemcounter
 
 import (
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 
 	"github.com/ubports/ubuntu-push/bus"
 	"github.com/ubports/ubuntu-push/click"

--- a/bus/emblemcounter/emblemcounter_test.go
+++ b/bus/emblemcounter/emblemcounter_test.go
@@ -19,7 +19,7 @@ package emblemcounter
 import (
 	"testing"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	testibus "github.com/ubports/ubuntu-push/bus/testing"

--- a/bus/endpoint.go
+++ b/bus/endpoint.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 
 	"github.com/ubports/ubuntu-push/logger"
 )

--- a/bus/networkmanager/networkmanager.go
+++ b/bus/networkmanager/networkmanager.go
@@ -21,7 +21,7 @@
 package networkmanager
 
 import (
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 
 	"github.com/ubports/ubuntu-push/bus"
 	"github.com/ubports/ubuntu-push/logger"

--- a/bus/networkmanager/networkmanager_test.go
+++ b/bus/networkmanager/networkmanager_test.go
@@ -19,7 +19,7 @@ package networkmanager
 import (
 	"testing"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	testingbus "github.com/ubports/ubuntu-push/bus/testing"

--- a/bus/notifications/raw.go
+++ b/bus/notifications/raw.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 
 	"github.com/ubports/ubuntu-push/bus"
 	"github.com/ubports/ubuntu-push/click"

--- a/bus/notifications/raw_test.go
+++ b/bus/notifications/raw_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	"github.com/ubports/ubuntu-push/bus"

--- a/bus/testing/testing_endpoint.go
+++ b/bus/testing/testing_endpoint.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 
 	"github.com/ubports/ubuntu-push/bus"
 	"github.com/ubports/ubuntu-push/testing/condition"

--- a/bus/testing/testing_endpoint_test.go
+++ b/bus/testing/testing_endpoint_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	"github.com/ubports/ubuntu-push/bus"

--- a/bus/urfkill/urfkill.go
+++ b/bus/urfkill/urfkill.go
@@ -19,7 +19,7 @@
 package urfkill
 
 import (
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 
 	"github.com/ubports/ubuntu-push/bus"
 	"github.com/ubports/ubuntu-push/logger"

--- a/bus/urfkill/urfkill_test.go
+++ b/bus/urfkill/urfkill_test.go
@@ -19,7 +19,7 @@ package urfkill
 import (
 	"testing"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	testingbus "github.com/ubports/ubuntu-push/bus/testing"

--- a/click/click.go
+++ b/click/click.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"sync"
 
-	"launchpad.net/go-xdg/v0"
+	"launchpad.net/go-xdg"
 
 	"github.com/ubports/ubuntu-push/click/cappinfo"
 	"github.com/ubports/ubuntu-push/click/cclick"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	"github.com/ubports/ubuntu-push/bus"

--- a/client/service/postal_test.go
+++ b/client/service/postal_test.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"launchpad.net/go-dbus/v1"
+	"launchpad.net/go-dbus"
 	. "launchpad.net/gocheck"
 
 	"github.com/ubports/ubuntu-push/bus"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/ubports/ubuntu-push
+
+go 1.13
+
+require (
+	github.com/mattn/go-sqlite3 v1.1.1-0.20160927022846-4b0af852c171
+	github.com/pborman/uuid v0.0.0-20160824210600-b984ec7fa9ff
+	launchpad.net/go-dbus v1.0.0-20140208094800-gubd5md7cro3mtxa
+	launchpad.net/go-xdg v0.0.0-20140208094800-000000000010
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087
+)
+
+replace launchpad.net/go-dbus => github.com/z3ntu/go-dbus v0.0.0-20170220120108-c022b8b2e127

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/mattn/go-sqlite3 v1.1.1-0.20160927022846-4b0af852c171 h1:bZY9z+CAvIbrKtvxl9Ypy+foX2hxuR5Q+2gziez44CM=
+github.com/mattn/go-sqlite3 v1.1.1-0.20160927022846-4b0af852c171/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/pborman/uuid v0.0.0-20160824210600-b984ec7fa9ff h1:pTiDfW+iOjIxjZeCm88gKn/AmR09UGZYZdqif2yPRrM=
+github.com/pborman/uuid v0.0.0-20160824210600-b984ec7fa9ff/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
+github.com/z3ntu/go-dbus v0.0.0-20170220120108-c022b8b2e127 h1:5uM5CyMgvx0a/ctLJ3ThGt2fghWoX6cPniYNgGeCuJI=
+github.com/z3ntu/go-dbus v0.0.0-20170220120108-c022b8b2e127/go.mod h1:bUTQ2+DQ82yitPELjqsyPbSZGg05fEKaC3eHCGkCiV4=
+launchpad.net/go-xdg v0.0.0-20140208094800-000000000010 h1:67YK4VRwVpu+qdmji/6lNv7y/O6NmH1oaSb/4ETtTck=
+launchpad.net/go-xdg v0.0.0-20140208094800-000000000010/go.mod h1:LvhuQF+z2nM+7tjWchL2jH2sbCGTtyHFhi4s/dDQEOk=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=

--- a/launch_helper/helper_finder/helper_finder.go
+++ b/launch_helper/helper_finder/helper_finder.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"launchpad.net/go-xdg/v0"
+	"launchpad.net/go-xdg"
 
 	"github.com/ubports/ubuntu-push/click"
 	"github.com/ubports/ubuntu-push/logger"

--- a/launch_helper/kindpool.go
+++ b/launch_helper/kindpool.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	xdg "launchpad.net/go-xdg/v0"
+	xdg "launchpad.net/go-xdg"
 
 	"github.com/ubports/ubuntu-push/click"
 	"github.com/ubports/ubuntu-push/launch_helper/cual"

--- a/launch_helper/kindpool_test.go
+++ b/launch_helper/kindpool_test.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"time"
 
-	xdg "launchpad.net/go-xdg/v0"
+	xdg "launchpad.net/go-xdg"
 	. "launchpad.net/gocheck"
 
 	"github.com/ubports/ubuntu-push/click"

--- a/sounds/sounds.go
+++ b/sounds/sounds.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/go-xdg/v0"
+	"launchpad.net/go-xdg"
 
 	"github.com/ubports/ubuntu-push/bus/accounts"
 	"github.com/ubports/ubuntu-push/click"

--- a/ubuntu-push-client.go
+++ b/ubuntu-push-client.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 	"syscall"
 
-	"launchpad.net/go-xdg/v0"
+	"launchpad.net/go-xdg"
 
 	"github.com/ubports/ubuntu-push/client"
 )


### PR DESCRIPTION
~~Currently one binary gets built: `ubuntu-push`~~ see below

The version suffixes had to be removed because go mod don't like those

See https://github.com/golang/go/wiki/Modules#semantic-import-versioning:

> If the module is version v0 or v1, do not include the major version in
  either the module path or the import path.

Unfortunately I had to mirror `go-dbus` to my GitHub account (see `replace` line in `go.mod`) because go mod got really confused with the launchpad setup of that repo and failed to download the dependency. go-xdg from launchpad works fine.

The new build procedure is:
* `git clone https://github.com/ubports/ubuntu-push && cd ubuntu-push`
* `go build -o ubuntu-push-client ubuntu-push-client.go`
* `go build -o push-server-dev server/dev/server.go` (these two commands should be automated in the Makefile - maybe like https://git.sr.ht/~sircmpwn/aerc/tree/master/Makefile ?)
* done!