### PR TITLE
Limit number of simultaneous connections to prevent DoS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
  golang-go,
  golang-go-dbus-dev,
  golang-go-xdg-dev,
+ golang-golang-x-net-dev,
  golang-gopkg-check.v1-dev | golang-gocheck-dev,
  libclick-0.4-dev,
  libdbus-1-dev,

--- a/server/runner_http.go
+++ b/server/runner_http.go
@@ -42,7 +42,7 @@ func HTTPServeRunner(httpLst net.Listener, h http.Handler, parsedCfg *HTTPServeP
 		if err != nil {
 			BootLogFatalf("start http listening: %v", err)
 		}
-		httpLst = netutil.LimitListener(httpLst, 200)
+		httpLst = netutil.LimitListener(httpLst, 2000)
 	}
 	BootLogListener("http", httpLst)
 	srv := &http.Server{
@@ -52,7 +52,7 @@ func HTTPServeRunner(httpLst net.Listener, h http.Handler, parsedCfg *HTTPServeP
 	}
 	if tlsCfg != nil {
 		httpLst = tls.NewListener(httpLst, tlsCfg)
-		httpLst = netutil.LimitListener(httpLst, 100)
+		httpLst = netutil.LimitListener(httpLst, 1000)
 	}
 	return func() {
 		err := srv.Serve(httpLst)

--- a/server/runner_http.go
+++ b/server/runner_http.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"golang.org/x/net/netutil"
 
 	"github.com/ubports/ubuntu-push/config"
 )
@@ -41,6 +42,7 @@ func HTTPServeRunner(httpLst net.Listener, h http.Handler, parsedCfg *HTTPServeP
 		if err != nil {
 			BootLogFatalf("start http listening: %v", err)
 		}
+		httpLst = netutil.LimitListener(httpLst, 200)
 	}
 	BootLogListener("http", httpLst)
 	srv := &http.Server{
@@ -50,6 +52,7 @@ func HTTPServeRunner(httpLst net.Listener, h http.Handler, parsedCfg *HTTPServeP
 	}
 	if tlsCfg != nil {
 		httpLst = tls.NewListener(httpLst, tlsCfg)
+		httpLst = netutil.LimitListener(httpLst, 100)
 	}
 	return func() {
 		err := srv.Serve(httpLst)


### PR DESCRIPTION
From the running server deployment:
When the server is down Telegram will enqueue messages to be sent and then flood us with 1000s of simlutaneous connections. We are not AWS, so limit it to a sane level.
