### PR TITLE
Sync Github with the deployed stats improvements

### DIFF
--- a/server/api/handlers.go
+++ b/server/api/handlers.go
@@ -26,6 +26,7 @@ import (
 	"mime"
 	"net/http"
 	"time"
+	"strings"
 
 	"github.com/pborman/uuid"
 
@@ -429,6 +430,7 @@ func doBroadcast(ctx *context, sto store.PendingStore, parsedBodyObj interface{}
 	}
 
 	ctx.broker.Broadcast(chanId)
+	ctx.logger.Infof("broadcast: %v %v %v", chanId, bcast.Data, expire)
 	return nil, nil
 }
 
@@ -456,21 +458,30 @@ func doUnicast(ctx *context, sto store.PendingStore, parsedBodyObj interface{}) 
 	if apiErr != nil {
 		return nil, apiErr
 	}
-	chanId, err := sto.GetInternalChannelIdFromToken(ucast.Token, ucast.AppId, ucast.UserId, ucast.DeviceId)
+	//Extract app Id from token rather than using the supplied one. This supports multiple apps using the same push GW
+	decoded, err := base64.StdEncoding.DecodeString(ucast.Token)
+	if err != nil {
+		ctx.logger.Errorf("could not decode token:v", err)
+		return nil, ErrUnknownToken
+	}
+	token := string(decoded)
+	appId := strings.Split(token, ":")[0]
+	ctx.logger.Infof("App id extracted from token: %v", appId)
+	chanId, err := sto.GetInternalChannelIdFromToken(ucast.Token, appId, ucast.UserId, ucast.DeviceId)
 	if err != nil {
 		switch err {
 		case store.ErrUnknownToken:
-			ctx.logger.Debugf("notify: %v %v unknown", ucast.AppId, ucast.Token)
+			ctx.logger.Debugf("notify: %v %v unknown", appId, ucast.Token)
 			return nil, ErrUnknownToken
 		case store.ErrUnauthorized:
-			ctx.logger.Debugf("notify: %v %v unauthorized", ucast.AppId, ucast.Token)
+			ctx.logger.Debugf("notify: %v %v unauthorized", appId, ucast.Token)
 			return nil, ErrUnauthorized
 		default:
 			ctx.logger.Errorf("could not resolve token: %v", err)
 			return nil, ErrCouldNotResolveToken
 		}
 	}
-	ctx.logger.Infof("notify: %v %v -> %v", ucast.AppId, ucast.Token, chanId)
+	ctx.logger.Infof("notify: %v %v -> %v", appId, ucast.Token, chanId)
 
 	_, notifs, meta, err := sto.GetChannelUnfiltered(chanId)
 	if err != nil {
@@ -489,7 +500,7 @@ func doUnicast(ctx *context, sto store.PendingStore, parsedBodyObj interface{}) 
 			expired++
 			continue
 		}
-		if notif.AppId == ucast.AppId {
+		if notif.AppId == appId {
 			if replaceTag != "" && replaceTag == meta[i].ReplaceTag {
 				// this we will scrub
 				replaceable++
@@ -500,13 +511,13 @@ func doUnicast(ctx *context, sto store.PendingStore, parsedBodyObj interface{}) 
 		last = &notif
 	}
 	if ucast.ClearPending {
-		scrubCriteria = []string{ucast.AppId}
+		scrubCriteria = []string{appId}
 	} else if forApp >= ctx.storage.GetMaxNotificationsPerApplication() {
-		ctx.logger.Debugf("notify: %v %v too many pending", ucast.AppId, chanId)
+		ctx.logger.Debugf("notify: %v %v too many pending", appId, chanId)
 		return nil, apiErrorWithExtra(ErrTooManyPendingNotifications,
 			&last.Payload)
 	} else if replaceable > 0 {
-		scrubCriteria = []string{ucast.AppId, replaceTag}
+		scrubCriteria = []string{appId, replaceTag}
 	}
 	if expired > 0 || scrubCriteria != nil {
 		err := sto.Scrub(chanId, scrubCriteria...)
@@ -522,16 +533,15 @@ func doUnicast(ctx *context, sto store.PendingStore, parsedBodyObj interface{}) 
 		Expiration: expire,
 		ReplaceTag: ucast.ReplaceTag,
 	}
-
-	err = sto.AppendToUnicastChannel(chanId, ucast.AppId, ucast.Data, msgId, meta1)
+	err = sto.AppendToUnicastChannel(chanId, appId, ucast.Data, msgId, meta1)
 	if err != nil {
 		ctx.logger.Errorf("could not store notification: %v", err)
 		return nil, ErrCouldNotStoreNotification
 	}
 
-	ctx.broker.Unicast(chanId)
+	go ctx.broker.Unicast(chanId)
 
-	ctx.logger.Debugf("notify: ok %v %v id:%v clear:%v replace:%v expired:%v", ucast.AppId, chanId, msgId, ucast.ClearPending, replaceable, expired)
+	ctx.logger.Debugf("notify: ok %v %v id:%v clear:%v replace:%v expired:%v", appId, chanId, msgId, ucast.ClearPending, replaceable, expired)
 	return nil, nil
 }
 

--- a/server/broker/simple/simple.go
+++ b/server/broker/simple/simple.go
@@ -197,6 +197,7 @@ func (b *SimpleBroker) Register(connect *protocol.ConnectMsg, track broker.Sessi
 		return nil, err
 	}
 	b.logger.Infof("Registered the following device info: %v %v", sess.model, sess.imageChannel)
+	b.currentStats.IncreaseDevices(sess.model, sess.imageChannel)
 	return sess, nil
 }
 
@@ -204,6 +205,7 @@ func (b *SimpleBroker) Register(connect *protocol.ConnectMsg, track broker.Sessi
 func (b *SimpleBroker) Unregister(s broker.BrokerSession) {
 	sess := s.(*simpleBrokerSession)
 	b.sessionCh <- sess
+	b.currentStats.DecreaseDevices(sess.model, sess.imageChannel)
 }
 
 func (b *SimpleBroker) get(chanId store.InternalChannelId, cachedOk bool) (int64, []protocol.Notification, error) {
@@ -264,6 +266,7 @@ Loop:
 				for _, sess := range b.registry {
 					sess.exchanges <- broadcastExchg
 				}
+				b.currentStats.IncreaseBroadcasts()
 			case unicastDelivery:
 				chanId := delivery.chanId
 				_, devId := chanId.UnicastUserAndDevice()
@@ -271,6 +274,7 @@ Loop:
 				if sess != nil {
 					sess.exchanges <- &broker.UnicastExchange{ChanId: chanId, CachedOk: false}
 				}
+				b.currentStats.IncreaseUnicasts()
 			}
 		}
 	}

--- a/server/broker/simple/simple_test.go
+++ b/server/broker/simple/simple_test.go
@@ -35,7 +35,7 @@ var testBrokerConfig = &testing.TestBrokerConfig{10, 5}
 
 func (s *simpleSuite) TestNew(c *C) {
 	sto := store.NewInMemoryPendingStore()
-	b := NewSimpleBroker(sto, testBrokerConfig, nil, nil)
+	b := NewSimpleBroker(sto, testBrokerConfig, nil)
 	c.Check(cap(b.sessionCh), Equals, 5)
 	c.Check(len(b.registry), Equals, 0)
 	c.Check(b.sto, Equals, sto)

--- a/server/broker/simple/suite_test.go
+++ b/server/broker/simple/suite_test.go
@@ -41,7 +41,7 @@ func (t testTracker) SessionId() string {
 
 var _ = Suite(&commonBrokerSuite{testsuite.CommonBrokerSuite{
 	MakeBroker: func(sto store.PendingStore, cfg broker.BrokerConfig, log logger.Logger) testsuite.FullBroker {
-		return NewSimpleBroker(sto, cfg, log, nil)
+		return NewSimpleBroker(sto, cfg, log)
 	},
 	MakeTracker: func(sessionId string) broker.SessionTracker {
 		return testTracker(sessionId)

--- a/server/statistics/statistics.go
+++ b/server/statistics/statistics.go
@@ -200,17 +200,17 @@ func (stats *Statistics) PrintStats() {
 		stats.logger.Infof("7 days  | %10v | %10v | %10v |", devices_online_7day, unicasts_total_7day, broadcasts_total_7day)
 		stats.logger.Infof("")
 		stats.logger.Infof("Device statistics:")
-		stats.logger.Infof("%15v | %10v | %10v | %10v | %10v", "Device", "5 mins","60 mins","1 day","7 days")
+		stats.logger.Infof("%20v | %10v | %10v | %10v | %10v", "Device", "5 mins","60 mins","1 day","7 days")
 		for key, value := range stats.devices_specific {
 			devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day = value.Report()
-		stats.logger.Infof("%15v | %10v | %10v | %10v | %10v", key, devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day)
+		stats.logger.Infof("%20v | %10v | %10v | %10v | %10v", key, devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day)
 		}
 		stats.logger.Infof("")
 		stats.logger.Infof("Channel statistics:")
-		stats.logger.Infof("%30v | %10v | %10v | %10v | %10v", "Channel", "5 mins","60 mins","1 day","7 days")
+		stats.logger.Infof("%35v | %10v | %10v | %10v | %10v", "Channel", "5 mins","60 mins","1 day","7 days")
 		for key, value := range stats.channel_specific {
 			devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day = value.Report()
-		stats.logger.Infof("%30v | %10v | %10v | %10v | %10v", key, devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day)
+		stats.logger.Infof("%35v | %10v | %10v | %10v | %10v", key, devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day)
 		}
 		stats.Reset5min()
 		stats.updating.Unlock()

--- a/server/statistics/statistics.go
+++ b/server/statistics/statistics.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 	"container/ring"
-	
+
 	"github.com/ubports/ubuntu-push/logger"
 )
 
@@ -30,7 +30,7 @@ func (statsvalue *StatsValue) Accumulate() {
 	statsvalue.val1day.Value = statsvalue.val5min
 	statsvalue.val1day = statsvalue.val1day.Next()
 	statsvalue.val7day.Value = statsvalue.val5min
-	statsvalue.val7day = statsvalue.val7day.Next()	
+	statsvalue.val7day = statsvalue.val7day.Next()
 }
 
 func (statsvalue *StatsValue) Reset5min() {
@@ -38,25 +38,28 @@ func (statsvalue *StatsValue) Reset5min() {
 }
 
 func (statsvalue *StatsValue) Report() (int32, int32, int32, int32) {
-	
+
 	var val60min int32 = 0
 	statsvalue.val60min.Do(func(p interface{}) {
 		if p != nil {
 			val60min += p.(int32)
 		}
 	})
+	val60min = val60min / 12
 	var val1day int32 = 0
 	statsvalue.val1day.Do(func(p interface{}) {
 		if p != nil {
 			val1day += p.(int32)
 		}
 	})
+	val1day = val1day / 288
 	var val7day int32 = 0
 	statsvalue.val7day.Do(func(p interface{}) {
 		if p != nil {
 			val7day += p.(int32)
 		}
-	})	
+	})
+	val7day = val7day / 2016
 	return statsvalue.val5min, val60min, val1day, val7day
 }
 
@@ -67,12 +70,19 @@ type Statistics struct {
 
 	//Devices currently online
 	devices_online *StatsValue
-	
+
 	//Total unicasts sent
 	unicasts_total *StatsValue
-	
+
 	//Total broadcasts sent
 	broadcasts_total *StatsValue
+
+	//Device-specific accumulation
+	devices_specific map[string]*StatsValue
+
+	//Channel-specific accumulation
+	channel_specific map[string]*StatsValue
+
 }
 
 func NewStatistics(logger logger.Logger) *Statistics {
@@ -93,6 +103,12 @@ func (stats *Statistics) Accumulate() {
 	stats.devices_online.Accumulate()
 	stats.unicasts_total.Accumulate()
 	stats.broadcasts_total.Accumulate()
+	for _, value := range stats.devices_specific {
+		value.Accumulate()
+	}
+	for _, value := range stats.channel_specific {
+		value.Accumulate()
+	}
 }
 
 func (stats *Statistics) Reset5min() {
@@ -100,15 +116,44 @@ func (stats *Statistics) Reset5min() {
 	stats.broadcasts_total.Reset5min()
 }
 
-func (stats *Statistics) DecreaseDevices() {
+func (stats *Statistics) DecreaseDevices(device_name string, channel_name string) {
 	stats.updating.Lock()
 	stats.devices_online.val5min--
+	if(stats.devices_specific == nil) {
+		stats.devices_specific = make(map[string]*StatsValue)
+	}
+	if(stats.devices_specific[device_name] == nil) {
+		stats.devices_specific[device_name] = NewStatsValue()
+	}
+	stats.devices_specific[device_name].val5min--
+	if(stats.channel_specific == nil) {
+		stats.channel_specific = make(map[string]*StatsValue)
+	}
+	if(stats.channel_specific[channel_name] == nil) {
+		stats.channel_specific[channel_name] = NewStatsValue()
+	}
+	stats.channel_specific[channel_name].val5min--
+
 	stats.updating.Unlock()
 }
 
-func (stats *Statistics) IncreaseDevices() {
+func (stats *Statistics) IncreaseDevices(device_name string, channel_name string) {
 	stats.updating.Lock()
 	stats.devices_online.val5min++
+    if(stats.devices_specific == nil) {
+	stats.devices_specific = make(map[string]*StatsValue)
+    }
+	if(stats.devices_specific[device_name] == nil) {
+		stats.devices_specific[device_name] = NewStatsValue()
+	}
+	stats.devices_specific[device_name].val5min++
+    if(stats.channel_specific == nil) {
+	stats.channel_specific = make(map[string]*StatsValue)
+	}
+	if(stats.channel_specific[channel_name] == nil) {
+		stats.channel_specific[channel_name] = NewStatsValue()
+	}
+    stats.channel_specific[channel_name].val5min++
 	stats.updating.Unlock()
 }
 
@@ -130,7 +175,8 @@ func (stats *Statistics) TestStats() {
 		stats.devices_online.val5min = 20
 		stats.IncreaseUnicasts()
 		stats.IncreaseBroadcasts()
-		<-t.C	
+		stats.IncreaseDevices("bacon", "16.04/rc")
+		<-t.C
 	}
 }
 
@@ -140,21 +186,35 @@ func (stats *Statistics) PrintStats() {
 	for {
 		stats.updating.Lock()
 		stats.Accumulate()
-		
+
 		//Tally the accumulated values
 		devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day := stats.devices_online.Report()
 		unicasts_total_5min, unicasts_total_60min, unicasts_total_1day, unicasts_total_7day := stats.unicasts_total.Report()
 		broadcasts_total_5min, broadcasts_total_60min, broadcasts_total_1day, broadcasts_total_7day := stats.broadcasts_total.Report()
-		
-		stats.logger.Infof("Current usage statistics:")
-		stats.logger.Infof("        |  Devices   |  Unicasts  | Broadcasts |")
+
+		stats.logger.Infof("Usage statistics:")
+		stats.logger.Infof("        |  Devices   |  Unicasts  |  Broadcasts |")
 		stats.logger.Infof("5 mins  | %10v | %10v | %10v |", devices_online_5min, unicasts_total_5min, broadcasts_total_5min)
-		stats.logger.Infof("60 mins | %10v | %10v | %10v |", devices_online_60min / 12, unicasts_total_60min, broadcasts_total_60min)
-		stats.logger.Infof("1 day   | %10v | %10v | %10v |", devices_online_1day / 288, unicasts_total_1day, broadcasts_total_1day)
-		stats.logger.Infof("7 days  | %10v | %10v | %10v |", devices_online_7day /2016, unicasts_total_7day, broadcasts_total_7day)
+		stats.logger.Infof("60 mins | %10v | %10v | %10v |", devices_online_60min, unicasts_total_60min, broadcasts_total_60min)
+		stats.logger.Infof("1 day   | %10v | %10v | %10v |", devices_online_1day, unicasts_total_1day, broadcasts_total_1day)
+		stats.logger.Infof("7 days  | %10v | %10v | %10v |", devices_online_7day, unicasts_total_7day, broadcasts_total_7day)
+		stats.logger.Infof("")
+		stats.logger.Infof("Device statistics:")
+		stats.logger.Infof("%15v | %10v | %10v | %10v | %10v", "Device", "5 mins","60 mins","1 day","7 days")
+		for key, value := range stats.devices_specific {
+			devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day = value.Report()
+		stats.logger.Infof("%15v | %10v | %10v | %10v | %10v", key, devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day)
+		}
+		stats.logger.Infof("")
+		stats.logger.Infof("Channel statistics:")
+		stats.logger.Infof("%30v | %10v | %10v | %10v | %10v", "Channel", "5 mins","60 mins","1 day","7 days")
+		for key, value := range stats.channel_specific {
+			devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day = value.Report()
+		stats.logger.Infof("%30v | %10v | %10v | %10v | %10v", key, devices_online_5min, devices_online_60min, devices_online_1day, devices_online_7day)
+		}
 		stats.Reset5min()
 		stats.updating.Unlock()
-		
+
 		//Wait until timer has elapsed
 		<-t.C
 	}


### PR DESCRIPTION
From the running server deployment:
Those changes were done on the server over time, but not brought back in here. Basically improving stats and also using the app id from the encrypted token than rather from the headers of the request. That allows the matrix gateway to handle notifications from different apps correctly.
